### PR TITLE
v0.1.11 - Adding 9092 to sg_kafka to support Kafka 0.8.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ service Terraform templates.
 - [sg_redis](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_redis) - This is a security group for Redis clusters
     - It allows incoming TCP 22 (SSH) and TCP 6379 (redis)
 - [sg_kafka](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_kafka) - This is a security group for Kafka clusters
-    - It allows incoming TCP 22 (SSH) and TCP 6667 (Kafka broker)
+    - It allows incoming TCP 22 (SSH), TCP 6667 (Kafka broker) TCP 9092 (Kafka broker)
 - [sg_cassandra](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_cassandra) - This is a security group for Cassandra clusters
     - It allows incoming TCP 22 (SSH), TCP 7199 (JMX), 9042 (Cassandra clients), 9160 (Cassandra Thrift clients)
 

--- a/sg_kafka/README.md
+++ b/sg_kafka/README.md
@@ -8,6 +8,7 @@ Ports
 -----
 - TCP 22
 - TCP 6667 (Kafka broker)
+- TCP 9092 (Kafka broker)
 
 Input Variables
 ---------------

--- a/sg_kafka/main.tf
+++ b/sg_kafka/main.tf
@@ -40,10 +40,18 @@ resource "aws_security_group" "main_security_group" {
         cidr_blocks = ["${var.source_cidr_block}"]
     }
 
-    // allow traffic for TCP 6667 (Kafka broker)
+    // allow traffic for TCP 6667 (Kafka broker 0.8.1.x)
     ingress {
         from_port = 6667
         to_port = 6667
+        protocol = "tcp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for TCP 9092 (Kafka broker 0.8.2+)
+    ingress {
+        from_port = 9092
+        to_port = 9092
         protocol = "tcp"
         cidr_blocks = ["${var.source_cidr_block}"]
     }


### PR DESCRIPTION
v0.1.11 - Adding 9092 to sg_kafka to support Kafka 0.8.2+

Fixes #3
