### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_web" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-web"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_web"
   security_group_name = "${var.security_group_name}-web"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_cassandra/README.md
+++ b/sg_cassandra/README.md
@@ -28,7 +28,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_web" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-consul"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_consul"
   security_group_name = "${var.security_group_name}-consul"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_consul/README.md
+++ b/sg_consul/README.md
@@ -32,7 +32,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_web" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-consul"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_consul"
   security_group_name = "${var.security_group_name}-consul"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_elasticsearch/README.md
+++ b/sg_elasticsearch/README.md
@@ -25,7 +25,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_elasticsearch" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-elasticsearch"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_elasticsearch"
   security_group_name = "${var.security_group_name}-elasticsearch"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_https_only/README.md
+++ b/sg_https_only/README.md
@@ -26,7 +26,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_web" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-https-only"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_https_only"
   security_group_name = "${var.security_group_name}-https"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_kafka/README.md
+++ b/sg_kafka/README.md
@@ -26,8 +26,8 @@ You can use these in your terraform template with the following steps.
 1. Adding a module resource to your template, e.g. `main.tf`
 
 ```
-module "sg-kafka" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-kafka"
+module "sg_kafka" {
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_kafka"
   security_group_name = "${var.security_group_name}-kafka"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_memcached/README.md
+++ b/sg_memcached/README.md
@@ -24,7 +24,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_web" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-memcached"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_memcached"
   security_group_name = "${var.security_group_name}-memcached"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_mysql/README.md
+++ b/sg_mysql/README.md
@@ -24,7 +24,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_mysql" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-mysql"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_mysql"
   security_group_name = "${var.security_group_name}-mysql"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_redis/README.md
+++ b/sg_redis/README.md
@@ -24,7 +24,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_redis" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-redis"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_redis"
   security_group_name = "${var.security_group_name}-redis"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_storm/README.md
+++ b/sg_storm/README.md
@@ -28,7 +28,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_storm" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-storm"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_storm"
   security_group_name = "${var.security_group_name}-storm"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_web/README.md
+++ b/sg_web/README.md
@@ -27,7 +27,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_web" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-web"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_web"
   security_group_name = "${var.security_group_name}-web"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_zipkin/README.md
+++ b/sg_zipkin/README.md
@@ -31,7 +31,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_zipkin" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-zipkin"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_zipkin"
   security_group_name = "${var.security_group_name}-zipkin"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"

--- a/sg_zookeeper/README.md
+++ b/sg_zookeeper/README.md
@@ -27,7 +27,7 @@ You can use these in your terraform template with the following steps.
 
 ```
 module "sg_zookeeper" {
-  source = "github.com/terraform-community-modules/tf_aws_sg//sg-zookeeper"
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_zookeeper"
   security_group_name = "${var.security_group_name}-zookeeper"
   aws_access_key = "${var.aws_access_key}"
   aws_secret_key = "${var.aws_secret_key}"


### PR DESCRIPTION
Most of the examples simply don't work and end up with similar errors:

> Error loading Terraform: Error downloading modules: module sg_web: open .terraform/modules/f551cceae759ac94eb586588d1bd61ce/sg-web: no such file or directory
