### PR TITLE
Removed need to pass in AWS param

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ You can use these in your terraform template with the following steps.
 module "sg_web" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_web"
   security_group_name = "${var.security_group_name}-web"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -64,9 +61,6 @@ module "sg_web" {
 
 2.) Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_cassandra/README.md
+++ b/sg_cassandra/README.md
@@ -30,9 +30,6 @@ You can use these in your terraform template with the following steps.
 module "sg_web" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_consul"
   security_group_name = "${var.security_group_name}-consul"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -40,9 +37,6 @@ module "sg_web" {
 
 2.) Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_cassandra/main.tf
+++ b/sg_cassandra/main.tf
@@ -4,13 +4,6 @@
 // - Ports for Cassandra taken from http://www.datastax.com/documentation/cassandra/2.0/cassandra/security/secureFireWall_r.html
 //
 
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_cassandra/variables.tf
+++ b/sg_cassandra/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_consul/README.md
+++ b/sg_consul/README.md
@@ -34,9 +34,6 @@ You can use these in your terraform template with the following steps.
 module "sg_consul" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_consul"
   security_group_name = "${var.security_group_name}-consul"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -44,9 +41,6 @@ module "sg_consul" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_consul/main.tf
+++ b/sg_consul/main.tf
@@ -4,13 +4,6 @@
 // - Ports for Consul take from https://www.consul.io/docs/agent/options.html - Ports Used
 //
 
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_consul/variables.tf
+++ b/sg_consul/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_elasticsearch/README.md
+++ b/sg_elasticsearch/README.md
@@ -27,9 +27,6 @@ You can use these in your terraform template with the following steps.
 module "sg_elasticsearch" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_elasticsearch"
   security_group_name = "${var.security_group_name}-elasticsearch"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -37,9 +34,6 @@ module "sg_elasticsearch" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_elasticsearch/main.tf
+++ b/sg_elasticsearch/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_elasticsearch/variables.tf
+++ b/sg_elasticsearch/variables.tf
@@ -10,9 +10,3 @@ variable "vpc_id" {
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_https_only/README.md
+++ b/sg_https_only/README.md
@@ -28,9 +28,6 @@ You can use these in your terraform template with the following steps.
 module "sg_web" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_https_only"
   security_group_name = "${var.security_group_name}-https"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -38,9 +35,6 @@ module "sg_web" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_https_only/main.tf
+++ b/sg_https_only/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_https_only/variables.tf
+++ b/sg_https_only/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_kafka/README.md
+++ b/sg_kafka/README.md
@@ -29,9 +29,6 @@ You can use these in your terraform template with the following steps.
 module "sg_kafka" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_kafka"
   security_group_name = "${var.security_group_name}-kafka"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -39,9 +36,6 @@ module "sg_kafka" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_kafka/main.tf
+++ b/sg_kafka/main.tf
@@ -3,13 +3,6 @@
 //
 //
 
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_kafka/variables.tf
+++ b/sg_kafka/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_ldap/README.md
+++ b/sg_ldap/README.md
@@ -26,9 +26,6 @@ You can use these in your terraform template with the following steps.
 module "sg_ldap" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_ldap"
   security_group_name = "${var.security_group_name}-ldap"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -36,9 +33,6 @@ module "sg_ldap" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_ldap/main.tf
+++ b/sg_ldap/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_ldap/variables.tf
+++ b/sg_ldap/variables.tf
@@ -10,9 +10,3 @@ variable "vpc_id" {
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_ldaps_only/README.md
+++ b/sg_ldaps_only/README.md
@@ -28,9 +28,6 @@ You can use these in your terraform template with the following steps.
 module "sg_ldaps" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_ldaps_only"
   security_group_name = "${var.security_group_name}-ldaps"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -38,9 +35,6 @@ module "sg_ldaps" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_ldaps_only/main.tf
+++ b/sg_ldaps_only/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_ldaps_only/variables.tf
+++ b/sg_ldaps_only/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_memcached/README.md
+++ b/sg_memcached/README.md
@@ -26,9 +26,6 @@ You can use these in your terraform template with the following steps.
 module "sg_web" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_memcached"
   security_group_name = "${var.security_group_name}-memcached"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -36,9 +33,6 @@ module "sg_web" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_memcached/main.tf
+++ b/sg_memcached/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_memcached/variables.tf
+++ b/sg_memcached/variables.tf
@@ -10,9 +10,3 @@ variable "vpc_id" {
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_mysql/README.md
+++ b/sg_mysql/README.md
@@ -26,9 +26,6 @@ You can use these in your terraform template with the following steps.
 module "sg_mysql" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_mysql"
   security_group_name = "${var.security_group_name}-mysql"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -36,9 +33,6 @@ module "sg_mysql" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_mysql/main.tf
+++ b/sg_mysql/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_mysql/variables.tf
+++ b/sg_mysql/variables.tf
@@ -10,9 +10,3 @@ variable "vpc_id" {
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_redis/README.md
+++ b/sg_redis/README.md
@@ -26,9 +26,6 @@ You can use these in your terraform template with the following steps.
 module "sg_redis" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_redis"
   security_group_name = "${var.security_group_name}-redis"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -36,9 +33,6 @@ module "sg_redis" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_redis/main.tf
+++ b/sg_redis/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_redis/variables.tf
+++ b/sg_redis/variables.tf
@@ -10,9 +10,3 @@ variable "vpc_id" {
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_storm/README.md
+++ b/sg_storm/README.md
@@ -30,9 +30,6 @@ You can use these in your terraform template with the following steps.
 module "sg_storm" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_storm"
   security_group_name = "${var.security_group_name}-storm"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -40,9 +37,6 @@ module "sg_storm" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_storm/main.tf
+++ b/sg_storm/main.tf
@@ -3,13 +3,6 @@
 //
 //
 
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_storm/variables.tf
+++ b/sg_storm/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_web/README.md
+++ b/sg_web/README.md
@@ -29,9 +29,6 @@ You can use these in your terraform template with the following steps.
 module "sg_web" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_web"
   security_group_name = "${var.security_group_name}-web"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -39,9 +36,6 @@ module "sg_web" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_web/main.tf
+++ b/sg_web/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_web/variables.tf
+++ b/sg_web/variables.tf
@@ -11,8 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
 
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_zipkin/README.md
+++ b/sg_zipkin/README.md
@@ -33,9 +33,6 @@ You can use these in your terraform template with the following steps.
 module "sg_zipkin" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_zipkin"
   security_group_name = "${var.security_group_name}-zipkin"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -43,9 +40,6 @@ module "sg_zipkin" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_zipkin/main.tf
+++ b/sg_zipkin/main.tf
@@ -4,13 +4,6 @@
 // - Ports for Zipkin
 //
 
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_zipkin/variables.tf
+++ b/sg_zipkin/variables.tf
@@ -11,9 +11,3 @@ variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
   default = "0.0.0.0/0"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}

--- a/sg_zookeeper/README.md
+++ b/sg_zookeeper/README.md
@@ -29,9 +29,6 @@ You can use these in your terraform template with the following steps.
 module "sg_zookeeper" {
   source = "github.com/terraform-community-modules/tf_aws_sg//sg_zookeeper"
   security_group_name = "${var.security_group_name}-zookeeper"
-  aws_access_key = "${var.aws_access_key}"
-  aws_secret_key = "${var.aws_secret_key}"
-  aws_region = "${var.aws_region}"
   vpc_id = "${var.vpc_id}"
   source_cidr_block = "${var.source_cidr_block}"
 }
@@ -39,9 +36,6 @@ module "sg_zookeeper" {
 
 2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
 
-- aws_access_key
-- aws_secret_key
-- aws_region
 - security_group_name
 - vpc_id
 - source_cidr_block

--- a/sg_zookeeper/main.tf
+++ b/sg_zookeeper/main.tf
@@ -1,10 +1,3 @@
-// Provider specific configs
-provider "aws" {
-    access_key = "${var.aws_access_key}"
-    secret_key = "${var.aws_secret_key}"
-    region = "${var.aws_region}"
-}
-
 // Security Group Resource for Module
 resource "aws_security_group" "main_security_group" {
     name = "${var.security_group_name}"

--- a/sg_zookeeper/variables.tf
+++ b/sg_zookeeper/variables.tf
@@ -10,9 +10,3 @@ variable "vpc_id" {
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
 }
-
-
-// Variables for providers used in this module
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_region" {}


### PR DESCRIPTION
The AWS provider can be configured at the top level template, and
doesn’t need to be specified in each module.

This makes the tf_aws_sg work like tf_aws_vpc module.  

There is now no need to create vars for  aws_access_key and aws_secret_key as these can now be read from ~/.aws/credentials file
