### PR TITLE
firewall rules for carbon-relay-ng

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ service Terraform templates.
     - It allows incoming TCP 636 (LDAPS)
 - [sg_ldaps_only](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_ldaps_only) - This is a security group for LDAPS only
     - It allows incoming TCP 636 (LDAPS)
-- [sg_carbon-relay-ng](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_carbon-realy-ng) - This is a security group for carbon-relay-ng
+- [sg_carbon-relay-ng](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_carbon-relay-ng) - This is a security group for carbon-relay-ng
     - It allows incoming TCP 22 (SSH), TCP 2003 (carbon-in), 2004 (admin), 2013 (pickle), 8081 (GUI) and UDP 2003 (carbon-in), 2013 (pickle)
 
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ service Terraform templates.
     - It allows incoming TCP 636 (LDAPS)
 - [sg_ldaps_only](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_ldaps_only) - This is a security group for LDAPS only
     - It allows incoming TCP 636 (LDAPS)
+- [sg_carbon-relay-ng](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_carbon-realy-ng) - This is a security group for carbon-relay-ng
+    - It allows incoming TCP 22 (SSH), TCP 2003 (carbon-in), 2004 (admin), 2013 (pickle), 8081 (GUI) and UDP 2003 (carbon-in), 2013 (pickle)
 
 
 Usage

--- a/sg_carbon-relay-ng/README.md
+++ b/sg_carbon-relay-ng/README.md
@@ -1,0 +1,46 @@
+sg_carbon-relay-ng terraform module
+==============================
+
+A Terraform security group module for carbon-relay-ng
+
+
+Ports
+-----
+- TCP 22
+- TCP 2003 (carbon-relay-ng carbon line-in)
+- UDP 2003 (carbon-relay-ng carbon line-in)
+- TCP 2013 (carbon-relay-ng carbon pickle)
+- UDP 2013 (carbon-relay-ng carbon pickle)
+- TCP 8081 (carbon-relay-ng carbon GUI)
+- TCP 2004 (carbon-relay-ng carbon admin port)
+
+
+Input Variables
+---------------
+
+- `security_group_name` - The name for your security group, e.g. `bluffdale_web_stage1`
+- `vpc_id` - The VPC this security group should be created in.
+- `source_cidr_block` - The source CIDR block, defaults to `0.0.0.0/0`
+   for this module.
+
+Usage
+-----
+
+You can use these in your terraform template with the following steps.
+
+1. Adding a module resource to your template, e.g. `main.tf`
+
+```
+module "sg_carbon-relay-ng" {
+  source = "github.com/terraform-community-modules/tf_aws_sg//sg_carbon-relay-ng"
+  security_group_name = "${var.security_group_name}-carbon-relay-ng"
+  vpc_id = "${var.vpc_id}"
+  source_cidr_block = "${var.source_cidr_block}"
+}
+```
+
+2. Setting values for the following variables, either through `terraform.tfvars` or `-var` arguments on the CLI
+
+- security_group_name
+- vpc_id
+- source_cidr_block

--- a/sg_carbon-relay-ng/main.tf
+++ b/sg_carbon-relay-ng/main.tf
@@ -1,0 +1,84 @@
+//
+// Module: tf_aws_sg/sg_carbon-relay-ng
+//
+//
+
+// Security Group Resource for Module
+resource "aws_security_group" "main_security_group" {
+    name = "${var.security_group_name}"
+    description = "Security Group ${var.security_group_name}"
+    vpc_id = "${var.vpc_id}"
+
+    // allows traffic from the SG itself for tcp
+    ingress {
+        from_port = 0
+        to_port = 65535
+        protocol = "tcp"
+        self = true
+    }
+
+    // allows traffic from the SG itself for udp
+    ingress {
+        from_port = 0
+        to_port = 65535
+        protocol = "udp"
+        self = true
+    }
+
+    // allow traffic for TCP 22 (SSH)
+    ingress {
+        from_port = 22
+        to_port = 22
+        protocol = "tcp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for TCP 2003 (for carbon line-in)
+    ingress {
+        from_port = 2003
+        to_port = 2003
+        protocol = "tcp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for UDP 2003 (for carbon line-in)
+    ingress {
+        from_port = 2003
+        to_port = 2003
+        protocol = "udp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for TCP 2013 (for pickle)
+    ingress {
+        from_port = 2013
+        to_port = 2013
+        protocol = "tcp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for UDP 2013 (for pickle)
+    ingress {
+        from_port = 2013
+        to_port = 2013
+        protocol = "udp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for TCP 2004 (admin port)
+    ingress {
+        from_port = 2004
+        to_port = 2004
+        protocol = "tcp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+    // allow traffic for TCP 8081 (for GUI)
+    ingress {
+        from_port = 8081
+        to_port = 8081
+        protocol = "tcp"
+        cidr_blocks = ["${var.source_cidr_block}"]
+    }
+
+}

--- a/sg_carbon-relay-ng/outputs.tf
+++ b/sg_carbon-relay-ng/outputs.tf
@@ -1,0 +1,4 @@
+// Output ID of sg_carbon-relay-ng SG we made
+output "security_group_id" {
+  value = "${aws_security_group.main_security_group.id}"
+}

--- a/sg_carbon-relay-ng/variables.tf
+++ b/sg_carbon-relay-ng/variables.tf
@@ -1,0 +1,13 @@
+// Module specific variables
+variable "security_group_name" {
+  description = "The name for the security group"
+}
+
+variable "vpc_id" {
+  description = "The VPC this security group will go in"
+}
+
+variable "source_cidr_block" {
+  description = "The source CIDR block to allow traffic from"
+  default = "0.0.0.0/0"
+}


### PR DESCRIPTION
added carbon-relay-ng which is one of the 3 major relay variants for graphite (carbon-c-relay/carbon-relay-ng/carbon-relay) 