### PR TITLE
Fix egress_all_all_all errors (sg_web)

### DIFF
--- a/sg_web/main.tf
+++ b/sg_web/main.tf
@@ -21,10 +21,12 @@ resource "aws_security_group_rule" "ingress_any_any_self" {
 
 // Allow egress all
 resource "aws_security_group_rule" "egress_all_all_all" {
+  security_group_id = "${aws_security_group.main_security_group.id}"
   from_port   = 0
   to_port     = 0
   protocol    = "-1"
-  cidr_blocks = "0.0.0.0/0"
+  cidr_blocks = ["0.0.0.0/0"]
+  type        = "egress"
 }
 
 // Allow TCP:80 (HTTP)


### PR DESCRIPTION
* module.sg_web.aws_security_group_rule.egress_all_all_all: "security_group_id": required field is not set
* module.sg_web.aws_security_group_rule.egress_all_all_all: "type": required field is not set
* module.sg_web.aws_security_group_rule.egress_all_all_all: cidr_blocks: should be a list