### PR TITLE
Add "type" for sg_elasticsearch ingress group rule

### DIFF
--- a/sg_elasticsearch/main.tf
+++ b/sg_elasticsearch/main.tf
@@ -16,6 +16,7 @@ resource "aws_security_group_rule" "ingress_any_any_self" {
   to_port           = 65535
   protocol          = "-1"
   self              = true
+  type              = "ingress"
 }
 
 // Allow TCP:9200 (REST Interface).


### PR DESCRIPTION
Add type for sg_elasticsearch group rule "ingress_any_any_self" to fix error:
module.sg_elasticsearch.aws_security_group_rule.ingress_any_any_self: "type": required field is not set