### PR TITLE
fix source_cidr_block is expected to be a list than a string

### DIFF
--- a/sg_https_only/variables.tf
+++ b/sg_https_only/variables.tf
@@ -9,7 +9,8 @@ variable "vpc_id" {
 
 variable "source_cidr_block" {
   description = "The source CIDR block to allow traffic from"
-  default     = "0.0.0.0/0"
+  default     = ["0.0.0.0/0"]
+  type        = "list"
 }
 
 variable "tags" {


### PR DESCRIPTION
I kept receiving the error `aws_security_group_rule.ingress_tcp_443_cidr: cidr_blocks: should be a list`. This is because the variable `source_cidr_block` is a string than a list.

This change allowed me to create the security group.