### PR TITLE
sg_openvpn - add 443 and 943

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ service Terraform templates.
 - [sg_carbon-relay-ng](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_carbon-relay-ng) - This is a security group for carbon-relay-ng
     - It allows incoming TCP 2003 (carbon-in), 2004 (admin), 2013 (pickle), 8081 (GUI) and UDP 2003 (carbon-in), 2013 (pickle)
 - [sg_openvpn](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_openvpn) - This is a security group for OpenVPN
-    - It allows incoming UDP 1194 (OpenVPN)
+    - It allows incoming UDP 1194 (OpenVPN), TCP 443 (user web port), TCP 943 (admin web port) 
 - [sg_docker_swarm](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_docker_swarm) - This is a security group for Docker Swarm
     - It allows incoming TCP 2377 (Swarm management communication), 7946 (Swarm node communication), UDP 7946 (Swarm node communication), 4789 (Swarm overlay network communication)
 

--- a/sg_openvpn/main.tf
+++ b/sg_openvpn/main.tf
@@ -28,3 +28,23 @@ resource "aws_security_group_rule" "ingress_udp_1194_cidr" {
   cidr_blocks       = "${var.source_cidr_block}"
   type              = "ingress"
 }
+
+// Allow TCP:943 (OpenVPN)
+resource "aws_security_group_rule" "ingress_tcp_943_cidr" {
+  security_group_id = "${aws_security_group.main_security_group.id}"
+  from_port         = 943
+  to_port           = 943
+  protocol          = "tcp"
+  self              = true
+  type              = "ingress"
+}
+
+// Allow TCP:443 (OpenVPN)
+resource "aws_security_group_rule" "ingress_tcp_443_cidr" {
+  security_group_id = "${aws_security_group.main_security_group.id}"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = "${var.source_cidr_block}"
+  type              = "ingress"
+}


### PR DESCRIPTION

Changelog 
     - added ports 943 (admin) and 443 (users)

Tests: 
- Tested in personal VPC
- Code is similar to tf_aws_openvpn where port 443 is open