### PR TITLE
Add TCP/UDP:8302(Serf WAN) to sg_consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ service Terraform templates.
 - [sg_https_only](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_https_only) - This is a security group for external HTTPS ELBs
     - It only allows incoming TCP 443 (HTTPS)
 - [sg_consul](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_consul) - This is a security group for Consul clusters
-    - It allows incoming TCP 8300 (Server RPC), TCP 8301 (Serf LAN), and UDP 8301 (Serf LAN)
+    - It allows incoming TCP 8300 (Server RPC), TCP 8301 (Serf LAN), UDP 8301 (Serf LAN), TCP 8302 (Serf WAN), and UDP 8302 (Serf WAN)
     - It allows incoming TCP 8400 (Consul RPC), TCP 8500 (Consul HTTP), TCP 8600 (Consul DNS), and UDP 8600 (Consul DNS)
 - [sg_redis](https://github.com/terraform-community-modules/tf_aws_sg/tree/master/sg_redis) - This is a security group for Redis clusters
     - It allows incoming TCP 6379 (redis)

--- a/sg_consul/README.md
+++ b/sg_consul/README.md
@@ -9,6 +9,8 @@ Ports
 - TCP 8300 (Server RPC)
 - TCP 8301 (Serf LAN)
 - UDP 8301 (Serf LAN)
+- TCP 8302 (Serf WAN)
+- UDP 8302 (Serf WAN)
 - TCP 8400 (Consul RPC)
 - TCP 8500 (Consul HTTP API)
 - TCP 8600 (Consul DNS)

--- a/sg_consul/main.tf
+++ b/sg_consul/main.tf
@@ -59,6 +59,26 @@ resource "aws_security_group_rule" "ingress_udp_8301_self" {
   type              = "ingress"
 }
 
+// Allow TCP:8302 (Serf WAN).
+resource "aws_security_group_rule" "ingress_tcp_8302_self" {
+  security_group_id = "${aws_security_group.main_security_group.id}"
+  from_port         = 8302
+  to_port           = 8302
+  protocol          = "tcp"
+  cidr_blocks       = "${var.source_cidr_block}"
+  type              = "ingress"
+}
+
+// Allow UDP:8302 (Serf WAN).
+resource "aws_security_group_rule" "ingress_udp_8302_self" {
+  security_group_id = "${aws_security_group.main_security_group.id}"
+  from_port         = 8302
+  to_port           = 8302
+  protocol          = "udp"
+  cidr_blocks       = "${var.source_cidr_block}"
+  type              = "ingress"
+}
+
 // Allow TCP:8600 (Consul DNS).
 resource "aws_security_group_rule" "ingress_tcp_8600_self" {
   security_group_id = "${aws_security_group.main_security_group.id}"


### PR DESCRIPTION
This PR is able to communicate with consul-server to consul-server.
The reason is that in order to manage multi-dc.

ref: https://www.consul.io/docs/agent/options.html#ports-used